### PR TITLE
feat: add comprehensive recurring template management interface

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -45,6 +45,7 @@ interface TodoAPI {
 
 export type CreateTodoItemRequest = {
     title: string
+    due_date?: string
 }
 
 export type CreateTodoItemResponse = {
@@ -102,6 +103,14 @@ export type CreateRecurringTemplateRequest = {
     end_date?: string
 }
 
+export type UpdateRecurringTemplateRequest = {
+    title: string
+    recurrence_interval: RecurrenceInterval
+    start_date?: string
+    end_date?: string
+    is_active: boolean
+}
+
 export type RecurringTemplateResponse = {
     todo_name: string
     template_id: string
@@ -115,11 +124,31 @@ export type RecurringTemplateResponse = {
     update_time: string
 }
 
+export type ListRecurringTemplatesResponse = {
+    templates: RecurringTemplateResponse[]
+}
+
 interface RecurringTemplateAPI {
     CreateRecurringTemplate(
         todo_name: string,
         r: CreateRecurringTemplateRequest
     ): Promise<RecurringTemplateResponse>
+    ListRecurringTemplates(
+        todo_name: string
+    ): Promise<ListRecurringTemplatesResponse>
+    GetRecurringTemplate(
+        todo_name: string,
+        template_id: string
+    ): Promise<RecurringTemplateResponse>
+    UpdateRecurringTemplate(
+        todo_name: string,
+        template_id: string,
+        r: UpdateRecurringTemplateRequest
+    ): Promise<RecurringTemplateResponse>
+    DeleteRecurringTemplate(
+        todo_name: string,
+        template_id: string
+    ): Promise<void>
 }
 
 export const FinalTodoAPI: TodoAPI = BackendTodoAPI

--- a/frontend/src/api/recurring_template_api.ts
+++ b/frontend/src/api/recurring_template_api.ts
@@ -1,6 +1,8 @@
 import {
     CreateRecurringTemplateRequest,
+    UpdateRecurringTemplateRequest,
     RecurringTemplateResponse,
+    ListRecurringTemplatesResponse,
     BASE_URL,
 } from '.'
 
@@ -18,5 +20,62 @@ export const BackendRecurringTemplateAPI = {
             body: JSON.stringify(r),
         }
         return await fetch(url, options).then((r) => r.json())
+    },
+
+    ListRecurringTemplates: async (
+        todo_name: string
+    ): Promise<ListRecurringTemplatesResponse> => {
+        const url = `${BASE_URL}/todo/${todo_name}/recurring`
+        const options: RequestInit = {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        }
+        return await fetch(url, options).then((r) => r.json())
+    },
+
+    GetRecurringTemplate: async (
+        todo_name: string,
+        template_id: string
+    ): Promise<RecurringTemplateResponse> => {
+        const url = `${BASE_URL}/todo/${todo_name}/recurring/${template_id}`
+        const options: RequestInit = {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        }
+        return await fetch(url, options).then((r) => r.json())
+    },
+
+    UpdateRecurringTemplate: async (
+        todo_name: string,
+        template_id: string,
+        r: UpdateRecurringTemplateRequest
+    ): Promise<RecurringTemplateResponse> => {
+        const url = `${BASE_URL}/todo/${todo_name}/recurring/${template_id}`
+        const options: RequestInit = {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(r),
+        }
+        return await fetch(url, options).then((r) => r.json())
+    },
+
+    DeleteRecurringTemplate: async (
+        todo_name: string,
+        template_id: string
+    ): Promise<void> => {
+        const url = `${BASE_URL}/todo/${todo_name}/recurring/${template_id}`
+        const options: RequestInit = {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        }
+        await fetch(url, options)
     },
 }

--- a/frontend/src/api/useRecurringTemplateOperations.ts
+++ b/frontend/src/api/useRecurringTemplateOperations.ts
@@ -1,5 +1,24 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { FinalRecurringTemplateAPI, CreateRecurringTemplateRequest } from '.'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { 
+    FinalRecurringTemplateAPI, 
+    CreateRecurringTemplateRequest,
+    UpdateRecurringTemplateRequest 
+} from '.'
+
+export const useListRecurringTemplates = (todoName: string) => {
+    return useQuery({
+        queryKey: ['recurring-templates', todoName],
+        queryFn: () => FinalRecurringTemplateAPI.ListRecurringTemplates(todoName),
+    })
+}
+
+export const useGetRecurringTemplate = (todoName: string, templateId: string) => {
+    return useQuery({
+        queryKey: ['recurring-template', todoName, templateId],
+        queryFn: () => FinalRecurringTemplateAPI.GetRecurringTemplate(todoName, templateId),
+        enabled: !!todoName && !!templateId,
+    })
+}
 
 export const useCreateRecurringTemplate = () => {
     const queryClient = useQueryClient()
@@ -19,6 +38,61 @@ export const useCreateRecurringTemplate = () => {
         onSuccess: (data, variables) => {
             queryClient.invalidateQueries({
                 queryKey: ['recurring-templates', variables.todo_name],
+            })
+        },
+    })
+}
+
+export const useUpdateRecurringTemplate = () => {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: ({
+            todo_name,
+            template_id,
+            template,
+        }: {
+            todo_name: string
+            template_id: string
+            template: UpdateRecurringTemplateRequest
+        }) =>
+            FinalRecurringTemplateAPI.UpdateRecurringTemplate(
+                todo_name,
+                template_id,
+                template
+            ),
+        onSuccess: (data, variables) => {
+            queryClient.invalidateQueries({
+                queryKey: ['recurring-templates', variables.todo_name],
+            })
+            queryClient.invalidateQueries({
+                queryKey: ['recurring-template', variables.todo_name, variables.template_id],
+            })
+        },
+    })
+}
+
+export const useDeleteRecurringTemplate = () => {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: ({
+            todo_name,
+            template_id,
+        }: {
+            todo_name: string
+            template_id: string
+        }) =>
+            FinalRecurringTemplateAPI.DeleteRecurringTemplate(
+                todo_name,
+                template_id
+            ),
+        onSuccess: (data, variables) => {
+            queryClient.invalidateQueries({
+                queryKey: ['recurring-templates', variables.todo_name],
+            })
+            queryClient.removeQueries({
+                queryKey: ['recurring-template', variables.todo_name, variables.template_id],
             })
         },
     })

--- a/frontend/src/components/AppBreadcrumb.tsx
+++ b/frontend/src/components/AppBreadcrumb.tsx
@@ -29,8 +29,16 @@ export function AppBreadcrumb() {
         isPage: boolean
     }> = []
 
-    // Always start with Home
-    if (pathname !== '/') {
+    // Always show Home breadcrumb
+    if (pathname === '/') {
+        // On home page, show Home as current page (no link)
+        breadcrumbItems.push({
+            label: 'Home',
+            href: '/',
+            isPage: true,
+        })
+    } else {
+        // On other pages, show Home as link
         breadcrumbItems.push({
             label: 'Home',
             href: '/',
@@ -70,11 +78,40 @@ export function AppBreadcrumb() {
                     href: `/todo/${todoId}/new`,
                     isPage: true,
                 })
+            } else if (segments.length === 3 && segments[2] === 'templates') {
+                // /todo/$todoId/templates
+                breadcrumbItems.push({
+                    label: todoName,
+                    href: `/todo/${todoId}`,
+                    isPage: false,
+                })
+                breadcrumbItems.push({
+                    label: 'Templates',
+                    href: `/todo/${todoId}/templates`,
+                    isPage: true,
+                })
+            } else if (segments.length === 5 && segments[2] === 'template' && segments[4] === 'edit') {
+                // /todo/$todoId/template/$templateId/edit
+                breadcrumbItems.push({
+                    label: todoName,
+                    href: `/todo/${todoId}`,
+                    isPage: false,
+                })
+                breadcrumbItems.push({
+                    label: 'Templates',
+                    href: `/todo/${todoId}/templates`,
+                    isPage: false,
+                })
+                breadcrumbItems.push({
+                    label: 'Edit Template',
+                    href: `/todo/${todoId}/template/${segments[3]}/edit`,
+                    isPage: true,
+                })
             }
         }
     }
 
-    // Don't render breadcrumb if we're on home page with no additional context
+    // Always render breadcrumb now
     if (breadcrumbItems.length === 0) {
         return null
     }

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -15,157 +15,206 @@ import { Route as IndexImport } from './routes/index'
 import { Route as TodoNewImport } from './routes/todo.new'
 import { Route as TodoTodoIdImport } from './routes/todo.$todoId'
 import { Route as TodoTodoIdIndexImport } from './routes/todo.$todoId.index'
+import { Route as TodoTodoIdTemplatesImport } from './routes/todo.$todoId.templates'
 import { Route as TodoTodoIdNewImport } from './routes/todo.$todoId.new'
+import { Route as TodoTodoIdTemplateTemplateIdEditImport } from './routes/todo.$todoId.template.$templateId.edit'
 
 // Create/Update Routes
 
 const IndexRoute = IndexImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => rootRoute,
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRoute,
 } as any)
 
 const TodoNewRoute = TodoNewImport.update({
-    id: '/todo/new',
-    path: '/todo/new',
-    getParentRoute: () => rootRoute,
+  id: '/todo/new',
+  path: '/todo/new',
+  getParentRoute: () => rootRoute,
 } as any)
 
 const TodoTodoIdRoute = TodoTodoIdImport.update({
-    id: '/todo/$todoId',
-    path: '/todo/$todoId',
-    getParentRoute: () => rootRoute,
+  id: '/todo/$todoId',
+  path: '/todo/$todoId',
+  getParentRoute: () => rootRoute,
 } as any)
 
 const TodoTodoIdIndexRoute = TodoTodoIdIndexImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => TodoTodoIdRoute,
+  id: '/',
+  path: '/',
+  getParentRoute: () => TodoTodoIdRoute,
+} as any)
+
+const TodoTodoIdTemplatesRoute = TodoTodoIdTemplatesImport.update({
+  id: '/templates',
+  path: '/templates',
+  getParentRoute: () => TodoTodoIdRoute,
 } as any)
 
 const TodoTodoIdNewRoute = TodoTodoIdNewImport.update({
-    id: '/new',
-    path: '/new',
-    getParentRoute: () => TodoTodoIdRoute,
+  id: '/new',
+  path: '/new',
+  getParentRoute: () => TodoTodoIdRoute,
 } as any)
+
+const TodoTodoIdTemplateTemplateIdEditRoute =
+  TodoTodoIdTemplateTemplateIdEditImport.update({
+    id: '/template/$templateId/edit',
+    path: '/template/$templateId/edit',
+    getParentRoute: () => TodoTodoIdRoute,
+  } as any)
 
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
-    interface FileRoutesByPath {
-        '/': {
-            id: '/'
-            path: '/'
-            fullPath: '/'
-            preLoaderRoute: typeof IndexImport
-            parentRoute: typeof rootRoute
-        }
-        '/todo/$todoId': {
-            id: '/todo/$todoId'
-            path: '/todo/$todoId'
-            fullPath: '/todo/$todoId'
-            preLoaderRoute: typeof TodoTodoIdImport
-            parentRoute: typeof rootRoute
-        }
-        '/todo/new': {
-            id: '/todo/new'
-            path: '/todo/new'
-            fullPath: '/todo/new'
-            preLoaderRoute: typeof TodoNewImport
-            parentRoute: typeof rootRoute
-        }
-        '/todo/$todoId/new': {
-            id: '/todo/$todoId/new'
-            path: '/new'
-            fullPath: '/todo/$todoId/new'
-            preLoaderRoute: typeof TodoTodoIdNewImport
-            parentRoute: typeof TodoTodoIdImport
-        }
-        '/todo/$todoId/': {
-            id: '/todo/$todoId/'
-            path: '/'
-            fullPath: '/todo/$todoId/'
-            preLoaderRoute: typeof TodoTodoIdIndexImport
-            parentRoute: typeof TodoTodoIdImport
-        }
+  interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
     }
+    '/todo/$todoId': {
+      id: '/todo/$todoId'
+      path: '/todo/$todoId'
+      fullPath: '/todo/$todoId'
+      preLoaderRoute: typeof TodoTodoIdImport
+      parentRoute: typeof rootRoute
+    }
+    '/todo/new': {
+      id: '/todo/new'
+      path: '/todo/new'
+      fullPath: '/todo/new'
+      preLoaderRoute: typeof TodoNewImport
+      parentRoute: typeof rootRoute
+    }
+    '/todo/$todoId/new': {
+      id: '/todo/$todoId/new'
+      path: '/new'
+      fullPath: '/todo/$todoId/new'
+      preLoaderRoute: typeof TodoTodoIdNewImport
+      parentRoute: typeof TodoTodoIdImport
+    }
+    '/todo/$todoId/templates': {
+      id: '/todo/$todoId/templates'
+      path: '/templates'
+      fullPath: '/todo/$todoId/templates'
+      preLoaderRoute: typeof TodoTodoIdTemplatesImport
+      parentRoute: typeof TodoTodoIdImport
+    }
+    '/todo/$todoId/': {
+      id: '/todo/$todoId/'
+      path: '/'
+      fullPath: '/todo/$todoId/'
+      preLoaderRoute: typeof TodoTodoIdIndexImport
+      parentRoute: typeof TodoTodoIdImport
+    }
+    '/todo/$todoId/template/$templateId/edit': {
+      id: '/todo/$todoId/template/$templateId/edit'
+      path: '/template/$templateId/edit'
+      fullPath: '/todo/$todoId/template/$templateId/edit'
+      preLoaderRoute: typeof TodoTodoIdTemplateTemplateIdEditImport
+      parentRoute: typeof TodoTodoIdImport
+    }
+  }
 }
 
 // Create and export the route tree
 
 interface TodoTodoIdRouteChildren {
-    TodoTodoIdNewRoute: typeof TodoTodoIdNewRoute
-    TodoTodoIdIndexRoute: typeof TodoTodoIdIndexRoute
+  TodoTodoIdNewRoute: typeof TodoTodoIdNewRoute
+  TodoTodoIdTemplatesRoute: typeof TodoTodoIdTemplatesRoute
+  TodoTodoIdIndexRoute: typeof TodoTodoIdIndexRoute
+  TodoTodoIdTemplateTemplateIdEditRoute: typeof TodoTodoIdTemplateTemplateIdEditRoute
 }
 
 const TodoTodoIdRouteChildren: TodoTodoIdRouteChildren = {
-    TodoTodoIdNewRoute: TodoTodoIdNewRoute,
-    TodoTodoIdIndexRoute: TodoTodoIdIndexRoute,
+  TodoTodoIdNewRoute: TodoTodoIdNewRoute,
+  TodoTodoIdTemplatesRoute: TodoTodoIdTemplatesRoute,
+  TodoTodoIdIndexRoute: TodoTodoIdIndexRoute,
+  TodoTodoIdTemplateTemplateIdEditRoute: TodoTodoIdTemplateTemplateIdEditRoute,
 }
 
 const TodoTodoIdRouteWithChildren = TodoTodoIdRoute._addFileChildren(
-    TodoTodoIdRouteChildren
+  TodoTodoIdRouteChildren,
 )
 
 export interface FileRoutesByFullPath {
-    '/': typeof IndexRoute
-    '/todo/$todoId': typeof TodoTodoIdRouteWithChildren
-    '/todo/new': typeof TodoNewRoute
-    '/todo/$todoId/new': typeof TodoTodoIdNewRoute
-    '/todo/$todoId/': typeof TodoTodoIdIndexRoute
+  '/': typeof IndexRoute
+  '/todo/$todoId': typeof TodoTodoIdRouteWithChildren
+  '/todo/new': typeof TodoNewRoute
+  '/todo/$todoId/new': typeof TodoTodoIdNewRoute
+  '/todo/$todoId/templates': typeof TodoTodoIdTemplatesRoute
+  '/todo/$todoId/': typeof TodoTodoIdIndexRoute
+  '/todo/$todoId/template/$templateId/edit': typeof TodoTodoIdTemplateTemplateIdEditRoute
 }
 
 export interface FileRoutesByTo {
-    '/': typeof IndexRoute
-    '/todo/new': typeof TodoNewRoute
-    '/todo/$todoId/new': typeof TodoTodoIdNewRoute
-    '/todo/$todoId': typeof TodoTodoIdIndexRoute
+  '/': typeof IndexRoute
+  '/todo/new': typeof TodoNewRoute
+  '/todo/$todoId/new': typeof TodoTodoIdNewRoute
+  '/todo/$todoId/templates': typeof TodoTodoIdTemplatesRoute
+  '/todo/$todoId': typeof TodoTodoIdIndexRoute
+  '/todo/$todoId/template/$templateId/edit': typeof TodoTodoIdTemplateTemplateIdEditRoute
 }
 
 export interface FileRoutesById {
-    __root__: typeof rootRoute
-    '/': typeof IndexRoute
-    '/todo/$todoId': typeof TodoTodoIdRouteWithChildren
-    '/todo/new': typeof TodoNewRoute
-    '/todo/$todoId/new': typeof TodoTodoIdNewRoute
-    '/todo/$todoId/': typeof TodoTodoIdIndexRoute
+  __root__: typeof rootRoute
+  '/': typeof IndexRoute
+  '/todo/$todoId': typeof TodoTodoIdRouteWithChildren
+  '/todo/new': typeof TodoNewRoute
+  '/todo/$todoId/new': typeof TodoTodoIdNewRoute
+  '/todo/$todoId/templates': typeof TodoTodoIdTemplatesRoute
+  '/todo/$todoId/': typeof TodoTodoIdIndexRoute
+  '/todo/$todoId/template/$templateId/edit': typeof TodoTodoIdTemplateTemplateIdEditRoute
 }
 
 export interface FileRouteTypes {
-    fileRoutesByFullPath: FileRoutesByFullPath
-    fullPaths:
-        | '/'
-        | '/todo/$todoId'
-        | '/todo/new'
-        | '/todo/$todoId/new'
-        | '/todo/$todoId/'
-    fileRoutesByTo: FileRoutesByTo
-    to: '/' | '/todo/new' | '/todo/$todoId/new' | '/todo/$todoId'
-    id:
-        | '__root__'
-        | '/'
-        | '/todo/$todoId'
-        | '/todo/new'
-        | '/todo/$todoId/new'
-        | '/todo/$todoId/'
-    fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/todo/$todoId'
+    | '/todo/new'
+    | '/todo/$todoId/new'
+    | '/todo/$todoId/templates'
+    | '/todo/$todoId/'
+    | '/todo/$todoId/template/$templateId/edit'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/todo/new'
+    | '/todo/$todoId/new'
+    | '/todo/$todoId/templates'
+    | '/todo/$todoId'
+    | '/todo/$todoId/template/$templateId/edit'
+  id:
+    | '__root__'
+    | '/'
+    | '/todo/$todoId'
+    | '/todo/new'
+    | '/todo/$todoId/new'
+    | '/todo/$todoId/templates'
+    | '/todo/$todoId/'
+    | '/todo/$todoId/template/$templateId/edit'
+  fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
-    IndexRoute: typeof IndexRoute
-    TodoTodoIdRoute: typeof TodoTodoIdRouteWithChildren
-    TodoNewRoute: typeof TodoNewRoute
+  IndexRoute: typeof IndexRoute
+  TodoTodoIdRoute: typeof TodoTodoIdRouteWithChildren
+  TodoNewRoute: typeof TodoNewRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
-    IndexRoute: IndexRoute,
-    TodoTodoIdRoute: TodoTodoIdRouteWithChildren,
-    TodoNewRoute: TodoNewRoute,
+  IndexRoute: IndexRoute,
+  TodoTodoIdRoute: TodoTodoIdRouteWithChildren,
+  TodoNewRoute: TodoNewRoute,
 }
 
 export const routeTree = rootRoute
-    ._addFileChildren(rootRouteChildren)
-    ._addFileTypes<FileRouteTypes>()
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()
 
 /* ROUTE_MANIFEST_START
 {
@@ -185,7 +234,9 @@ export const routeTree = rootRoute
       "filePath": "todo.$todoId.tsx",
       "children": [
         "/todo/$todoId/new",
-        "/todo/$todoId/"
+        "/todo/$todoId/templates",
+        "/todo/$todoId/",
+        "/todo/$todoId/template/$templateId/edit"
       ]
     },
     "/todo/new": {
@@ -195,8 +246,16 @@ export const routeTree = rootRoute
       "filePath": "todo.$todoId.new.tsx",
       "parent": "/todo/$todoId"
     },
+    "/todo/$todoId/templates": {
+      "filePath": "todo.$todoId.templates.tsx",
+      "parent": "/todo/$todoId"
+    },
     "/todo/$todoId/": {
       "filePath": "todo.$todoId.index.tsx",
+      "parent": "/todo/$todoId"
+    },
+    "/todo/$todoId/template/$templateId/edit": {
+      "filePath": "todo.$todoId.template.$templateId.edit.tsx",
       "parent": "/todo/$todoId"
     }
   }

--- a/frontend/src/routes/todo.$todoId.index.tsx
+++ b/frontend/src/routes/todo.$todoId.index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { Plus, Trash2 } from 'lucide-react'
+import { Plus, Trash2, Clock } from 'lucide-react'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { getTodoQueryOptions } from '@/api/todoQueryOptions'
 import useDeleteTodo from '@/api/useDeleteTodo'
@@ -77,22 +77,36 @@ function RouteComponent() {
                     </div>
                 ) : (
                     <div>
-                        <div className="flex items-center justify-between mb-4">
+                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
                             <p className="text-sm text-gray-500">
                                 Manage your tasks and stay organized
                             </p>
-                            <Link
-                                className={buttonVariants({
-                                    variant: 'default',
-                                    size: 'sm',
-                                    className:
-                                        'gap-2 shadow-sm hover:shadow-md transition-shadow',
-                                })}
-                                to="/todo/$todoId/new"
-                                params={{ todoId }}
-                            >
-                                <Plus className="h-4 w-4" /> New Task
-                            </Link>
+                            <div className="flex flex-wrap gap-2">
+                                <Link
+                                    className={buttonVariants({
+                                        variant: 'outline',
+                                        size: 'sm',
+                                        className: 'gap-2',
+                                    })}
+                                    to="/todo/$todoId/templates"
+                                    params={{ todoId }}
+                                >
+                                    <Clock className="h-4 w-4" /> Templates
+                                </Link>
+                                <Link
+                                    className={buttonVariants({
+                                        variant: 'default',
+                                        size: 'sm',
+                                        className:
+                                            'gap-2 shadow-sm hover:shadow-md transition-shadow',
+                                    })}
+                                    to="/todo/$todoId/new"
+                                    params={{ todoId }}
+                                    search={{ recurring: false }}
+                                >
+                                    <Plus className="h-4 w-4" /> New Task
+                                </Link>
+                            </div>
                         </div>
                     </div>
                 )}

--- a/frontend/src/routes/todo.$todoId.new.tsx
+++ b/frontend/src/routes/todo.$todoId.new.tsx
@@ -12,14 +12,18 @@ import { useCreateRecurringTemplate } from '@/api/useRecurringTemplateOperations
 
 export const Route = createFileRoute('/todo/$todoId/new')({
     component: RouteComponent,
+    validateSearch: (search: Record<string, unknown>) => ({
+        recurring: search.recurring === true || search.recurring === 'true',
+    }),
 })
 
 function RouteComponent() {
     const todoId = Route.useParams().todoId
+    const search = Route.useSearch()
     const navigate = useNavigate()
     const [selectedDate, setSelectedDate] = React.useState<Date | undefined>()
     const [title, setTitle] = React.useState('')
-    const [isRecurring, setIsRecurring] = React.useState(false)
+    const [isRecurring, setIsRecurring] = React.useState(search.recurring || false)
     const [recurrenceInterval, setRecurrenceInterval] =
         React.useState<RecurrenceInterval>({ days: 1 })
     const [endDate, setEndDate] = React.useState<Date | undefined>()

--- a/frontend/src/routes/todo.$todoId.template.$templateId.edit.tsx
+++ b/frontend/src/routes/todo.$todoId.template.$templateId.edit.tsx
@@ -1,0 +1,239 @@
+import * as React from 'react'
+import { format } from 'date-fns'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { DatePicker } from '@/components/ui/datepicker'
+import { IntervalPicker } from '@/components/ui/interval-picker'
+import { Save } from 'lucide-react'
+import { RecurrenceInterval, UpdateRecurringTemplateRequest } from '@/api'
+import { 
+    useGetRecurringTemplate, 
+    useUpdateRecurringTemplate 
+} from '@/api/useRecurringTemplateOperations'
+
+export const Route = createFileRoute('/todo/$todoId/template/$templateId/edit')({
+    component: RouteComponent,
+})
+
+function RouteComponent() {
+    const { todoId, templateId } = Route.useParams()
+    const navigate = useNavigate()
+    const templateQuery = useGetRecurringTemplate(todoId, templateId)
+    const updateTemplateMutation = useUpdateRecurringTemplate()
+
+    const [title, setTitle] = React.useState('')
+    const [startDate, setStartDate] = React.useState<Date | undefined>()
+    const [endDate, setEndDate] = React.useState<Date | undefined>()
+    const [recurrenceInterval, setRecurrenceInterval] = React.useState<RecurrenceInterval>({ days: 1 })
+    const [isActive, setIsActive] = React.useState(true)
+
+    // Initialize form with existing template data
+    React.useEffect(() => {
+        if (templateQuery.data) {
+            setTitle(templateQuery.data.title)
+            setStartDate(new Date(templateQuery.data.start_date))
+            setEndDate(templateQuery.data.end_date ? new Date(templateQuery.data.end_date) : undefined)
+            setRecurrenceInterval(templateQuery.data.recurrence_interval)
+            setIsActive(templateQuery.data.is_active)
+        }
+    }, [templateQuery.data])
+
+    const handleFormSubmit = React.useCallback(
+        (event: React.FormEvent) => {
+            event.preventDefault()
+            const formData = new FormData(event.target as HTMLFormElement)
+            const titleValue = formData.get('title') as string
+
+            if (!titleValue.trim()) return
+
+            const updateRequest: UpdateRecurringTemplateRequest = {
+                title: titleValue.trim(),
+                recurrence_interval: recurrenceInterval,
+                start_date: startDate ? format(startDate, 'yyyy-MM-dd') : undefined,
+                end_date: endDate ? format(endDate, 'yyyy-MM-dd') : undefined,
+                is_active: isActive,
+            }
+
+            updateTemplateMutation.mutate(
+                {
+                    todo_name: todoId,
+                    template_id: templateId,
+                    template: updateRequest,
+                },
+                {
+                    onSuccess: () => {
+                        navigate({
+                            to: '/todo/$todoId/templates',
+                            params: { todoId },
+                        })
+                    },
+                }
+            )
+        },
+        [
+            updateTemplateMutation,
+            todoId,
+            templateId,
+            startDate,
+            endDate,
+            recurrenceInterval,
+            isActive,
+            navigate,
+        ]
+    )
+
+    if (templateQuery.isLoading) {
+        return (
+            <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6 mb-4">
+                <div className="animate-pulse space-y-4">
+                    <div className="h-8 bg-gray-200 rounded w-1/3"></div>
+                    <div className="space-y-2">
+                        <div className="h-4 bg-gray-200 rounded w-1/4"></div>
+                        <div className="h-10 bg-gray-200 rounded"></div>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    if (templateQuery.isError) {
+        return (
+            <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6 mb-4">
+                <div className="text-center py-12">
+                    <h3 className="mt-2 text-sm font-medium text-gray-900">Template not found</h3>
+                    <p className="mt-1 text-sm text-gray-500">
+                        The template you're looking for doesn't exist or has been deleted.
+                    </p>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <form onSubmit={handleFormSubmit}>
+            <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6 mb-4">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+                    <div className="space-y-1">
+                        <h1 className="text-xl sm:text-2xl font-semibold text-gray-900">
+                            Edit Template
+                        </h1>
+                        <p className="text-sm text-gray-500">
+                            Modify the recurring template settings
+                        </p>
+                    </div>
+                    <div className="flex gap-2">
+                        <Button
+                            type="submit"
+                            disabled={!title.trim() || updateTemplateMutation.isPending}
+                            className="gap-2"
+                        >
+                            <Save className="h-4 w-4" />
+                            {updateTemplateMutation.isPending ? 'Saving...' : 'Save Template'}
+                        </Button>
+                    </div>
+                </div>
+
+                <div className="space-y-6">
+                    <div>
+                        <label
+                            htmlFor="title"
+                            className="block text-sm font-medium text-gray-700 mb-1"
+                        >
+                            Template Title
+                        </label>
+                        <Input
+                            id="title"
+                            name="title"
+                            type="text"
+                            value={title}
+                            onChange={(e) => setTitle(e.target.value)}
+                            placeholder="Enter template title..."
+                            autoFocus
+                            className="w-full"
+                            required
+                        />
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label
+                                htmlFor="start-date"
+                                className="block text-sm font-medium text-gray-700 mb-1"
+                            >
+                                Start Date
+                            </label>
+                            <DatePicker
+                                date={startDate}
+                                onDateChange={setStartDate}
+                            />
+                        </div>
+
+                        <div>
+                            <label
+                                htmlFor="end-date"
+                                className="block text-sm font-medium text-gray-700 mb-1"
+                            >
+                                End Date (Optional)
+                            </label>
+                            <DatePicker
+                                date={endDate}
+                                onDateChange={setEndDate}
+                            />
+                            {endDate && (
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setEndDate(undefined)}
+                                    className="mt-1"
+                                >
+                                    Clear
+                                </Button>
+                            )}
+                        </div>
+                    </div>
+
+                    <div className="space-y-4 p-4 bg-gray-50 rounded-lg border">
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-2">
+                                Recurrence Settings
+                            </label>
+                            <IntervalPicker
+                                value={recurrenceInterval}
+                                onChange={setRecurrenceInterval}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="flex items-center space-x-2">
+                        <input
+                            id="is-active"
+                            type="checkbox"
+                            checked={isActive}
+                            onChange={(e) => setIsActive(e.target.checked)}
+                            className="rounded border-input"
+                        />
+                        <label
+                            htmlFor="is-active"
+                            className="text-sm font-medium text-gray-700"
+                        >
+                            Template is active
+                        </label>
+                        <span className="text-xs text-gray-500">
+                            (Inactive templates won't generate new items)
+                        </span>
+                    </div>
+
+                    {templateQuery.data?.last_generated_date && (
+                        <div className="text-sm text-gray-500 p-3 bg-blue-50 border border-blue-200 rounded-md">
+                            <strong>Last Generated:</strong>{' '}
+                            {new Date(templateQuery.data.last_generated_date).toLocaleDateString()}
+                        </div>
+                    )}
+
+                </div>
+            </div>
+        </form>
+    )
+}

--- a/frontend/src/routes/todo.$todoId.templates.tsx
+++ b/frontend/src/routes/todo.$todoId.templates.tsx
@@ -1,0 +1,203 @@
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { Plus, Edit, Trash2, Clock, Play, Pause } from 'lucide-react'
+import { Button, buttonVariants } from '@/components/ui/button'
+import { getTodoQueryOptions } from '@/api/todoQueryOptions'
+import { useListRecurringTemplates, useDeleteRecurringTemplate } from '@/api/useRecurringTemplateOperations'
+import { formatDistanceToNow } from 'date-fns'
+import * as React from 'react'
+
+export const Route = createFileRoute('/todo/$todoId/templates')({
+    component: RouteComponent,
+})
+
+function formatRecurrenceInterval(interval: { months?: number; days?: number; microseconds?: number }) {
+    const parts: string[] = []
+    
+    if (interval.months && interval.months > 0) {
+        parts.push(`${interval.months} month${interval.months > 1 ? 's' : ''}`)
+    }
+    if (interval.days && interval.days > 0) {
+        parts.push(`${interval.days} day${interval.days > 1 ? 's' : ''}`)
+    }
+    
+    return parts.join(', ') || 'Never'
+}
+
+function RouteComponent() {
+    const todoId = Route.useParams().todoId
+    const navigate = useNavigate()
+    const getTodoQuery = useSuspenseQuery(getTodoQueryOptions(todoId))
+    const templatesQuery = useListRecurringTemplates(todoId)
+    const deleteTemplateMutation = useDeleteRecurringTemplate()
+    
+    const [deleteConfirmId, setDeleteConfirmId] = React.useState<string | null>(null)
+
+    const handleDeleteClick = React.useCallback((templateId: string) => {
+        setDeleteConfirmId(templateId)
+    }, [])
+
+    const handleDeleteConfirm = React.useCallback((templateId: string) => {
+        deleteTemplateMutation.mutate(
+            { todo_name: todoId, template_id: templateId },
+            {
+                onSuccess: () => {
+                    setDeleteConfirmId(null)
+                },
+            }
+        )
+    }, [deleteTemplateMutation, todoId])
+
+    const handleDeleteCancel = React.useCallback(() => {
+        setDeleteConfirmId(null)
+    }, [])
+
+    return (
+        <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6 mb-4">
+            <div className="flex flex-col gap-6">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                    <div className="space-y-1">
+                        <h1 className="text-xl sm:text-2xl font-semibold text-gray-900">
+                            Recurring Templates
+                        </h1>
+                        <p className="text-sm text-gray-500">
+                            Manage templates for {getTodoQuery.data.name}
+                        </p>
+                    </div>
+                    <div className="flex gap-2">
+                        <Link
+                            className={buttonVariants({
+                                variant: 'default',
+                                size: 'sm',
+                                className: 'gap-2 shadow-sm hover:shadow-md transition-shadow',
+                            })}
+                            to="/todo/$todoId/new"
+                            params={{ todoId }}
+                            search={{ recurring: true }}
+                        >
+                            <Plus className="h-4 w-4" /> New Template
+                        </Link>
+                    </div>
+                </div>
+
+                {templatesQuery.data?.templates.length === 0 ? (
+                    <div className="text-center py-12">
+                        <Clock className="mx-auto h-12 w-12 text-gray-400" />
+                        <h3 className="mt-2 text-sm font-medium text-gray-900">No templates</h3>
+                        <p className="mt-1 text-sm text-gray-500">
+                            Get started by creating a recurring template
+                        </p>
+                        <div className="mt-6">
+                            <Link
+                                className={buttonVariants({
+                                    variant: 'default',
+                                    size: 'sm',
+                                    className: 'gap-2',
+                                })}
+                                to="/todo/$todoId/new"
+                                params={{ todoId }}
+                                search={{ recurring: true }}
+                            >
+                                <Plus className="h-4 w-4" /> New Template
+                            </Link>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        {templatesQuery.data?.templates.map((template) => (
+                            <div
+                                key={template.template_id}
+                                className="border border-gray-200 rounded-lg p-4 hover:border-gray-300 transition-colors"
+                            >
+                                <div className="flex items-start justify-between">
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 mb-2">
+                                            <h3 className="text-lg font-medium text-gray-900 truncate">
+                                                {template.title}
+                                            </h3>
+                                            <div className="flex items-center gap-1">
+                                                {template.is_active ? (
+                                                    <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-green-700 bg-green-50 border border-green-200 rounded-full">
+                                                        <Play className="h-3 w-3" />
+                                                        Active
+                                                    </span>
+                                                ) : (
+                                                    <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-gray-700 bg-gray-50 border border-gray-200 rounded-full">
+                                                        <Pause className="h-3 w-3" />
+                                                        Inactive
+                                                    </span>
+                                                )}
+                                            </div>
+                                        </div>
+                                        <div className="space-y-1 text-sm text-gray-500">
+                                            <p>
+                                                <span className="font-medium">Repeats:</span> Every{' '}
+                                                {formatRecurrenceInterval(template.recurrence_interval)}
+                                            </p>
+                                            <p>
+                                                <span className="font-medium">Start Date:</span>{' '}
+                                                {new Date(template.start_date).toLocaleDateString()}
+                                            </p>
+                                            {template.end_date && (
+                                                <p>
+                                                    <span className="font-medium">End Date:</span>{' '}
+                                                    {new Date(template.end_date).toLocaleDateString()}
+                                                </p>
+                                            )}
+                                            {template.last_generated_date && (
+                                                <p>
+                                                    <span className="font-medium">Last Generated:</span>{' '}
+                                                    {formatDistanceToNow(new Date(template.last_generated_date), { addSuffix: true })}
+                                                </p>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-2 ml-4">
+                                        {deleteConfirmId === template.template_id ? (
+                                            <div className="flex items-center gap-2">
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={handleDeleteCancel}
+                                                    disabled={deleteTemplateMutation.isPending}
+                                                >
+                                                    Cancel
+                                                </Button>
+                                                <Button
+                                                    variant="destructive"
+                                                    size="sm"
+                                                    onClick={() => handleDeleteConfirm(template.template_id)}
+                                                    disabled={deleteTemplateMutation.isPending}
+                                                >
+                                                    {deleteTemplateMutation.isPending ? 'Deleting...' : 'Delete'}
+                                                </Button>
+                                            </div>
+                                        ) : (
+                                            <>
+                                                <Link
+                                                    to="/todo/$todoId/template/$templateId/edit"
+                                                    params={{ todoId, templateId: template.template_id }}
+                                                    className="inline-flex items-center justify-center h-8 w-8 p-0 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-md transition-colors"
+                                                >
+                                                    <Edit className="h-4 w-4" />
+                                                </Link>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    onClick={() => handleDeleteClick(template.template_id)}
+                                                    className="h-8 w-8 p-0 text-gray-400 hover:text-red-600 hover:bg-red-50"
+                                                >
+                                                    <Trash2 className="h-4 w-4" />
+                                                </Button>
+                                            </>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/routes/todo.$todoId.tsx
+++ b/frontend/src/routes/todo.$todoId.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router'
 import { getTodoQueryOptions } from '@/api/todoQueryOptions'
 import { listTodoItemsQueryOptions } from '@/api/todoItemQueryOptions'
 import { useSuspenseQuery } from '@tanstack/react-query'
@@ -18,9 +18,13 @@ export const Route = createFileRoute('/todo/$todoId')({
 
 function RouteComponent() {
     const todoId = Route.useParams().todoId
+    const location = useLocation()
     const listTodoItemQuery = useSuspenseQuery(
         listTodoItemsQueryOptions(todoId)
     )
+    
+    // Check if we're on a subpage (templates, template edit, new item)
+    const isOnSubPage = location.pathname !== `/todo/${todoId}`
     const completeTodoItemMutation = useCompleteTodoItem(todoId)
     const [pendingCompletions, setPendingCompletions] = React.useState<
         Set<string>
@@ -87,7 +91,7 @@ function RouteComponent() {
             <div>
                 <Outlet />
             </div>
-            {listTodoItemQuery.data.items.length === 0 ? (
+            {!isOnSubPage && (listTodoItemQuery.data.items.length === 0 ? (
                 <div className="flex flex-col items-center justify-center py-12 sm:py-16 px-4 bg-gray-50 rounded-lg border border-dashed border-gray-200">
                     <div className="text-lg sm:text-2xl font-medium text-gray-500 mb-2">
                         No tasks yet
@@ -153,7 +157,7 @@ function RouteComponent() {
                         )
                     })}
                 </ul>
-            )}
+            ))}
         </div>
     )
 }


### PR DESCRIPTION
- Add complete frontend API layer with CRUD operations (list, get, update, delete)
- Create custom React Query hooks for all template operations
- Create dedicated templates management page (/todo/:todoId/templates)
- Create standalone template edit page with form validation
- Enhance breadcrumb navigation for template routes
- Add Templates button to todo detail page for easy access
- Hide todo items on template management pages for cleaner UX
- Support pre-selecting recurring mode when creating new templates
- Implement proper error handling and loading states

🤖 Generated with [Claude Code](https://claude.ai/code)