### PR TITLE
feat: implement 7-day advance todo generation for recurring templates

### DIFF
--- a/NOTE.md
+++ b/NOTE.md
@@ -19,7 +19,6 @@
 * Add cargo watch so that there is always a fresh copy when running the backend
   using run
 * Authentication and Authorization
-* Add recurring todos 
 * Add a test that we are not sending cookie and authorization headers in the logs
 * Add a test to check that we are sending the right logs
 * Change the assert_response to a macro to check for x-request-id, to give error message

--- a/backend/configuration/base.yaml
+++ b/backend/configuration/base.yaml
@@ -1,2 +1,5 @@
 application:
   port: 3000
+
+recurring:
+  advance_days: "7 days"

--- a/backend/migrations/20250210004708_create_initial_tables.sql
+++ b/backend/migrations/20250210004708_create_initial_tables.sql
@@ -6,10 +6,24 @@ CREATE TABLE todo (
     update_time timestamptz NOT NULL DEFAULT NOW()
 );
 
+-- Add recurring template table for storing recurrence rules
+CREATE TABLE recurring_template (
+    template_id uuid PRIMARY KEY,
+    todo_id uuid NOT NULL REFERENCES todo (todo_id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    recurrence_period INTERVAL NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NULL,
+    last_generated_date DATE NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    create_time timestamptz NOT NULL DEFAULT NOW(),
+    update_time timestamptz NOT NULL DEFAULT NOW()
+);
 
 CREATE TABLE todo_item (
     todo_item_id uuid PRIMARY KEY,
     todo_id uuid NOT NULL REFERENCES todo (todo_id) ON DELETE CASCADE,
+    recurring_template_id uuid NULL REFERENCES recurring_template (template_id) ON DELETE SET NULL,
     title TEXT NOT NULL,
     is_complete BOOLEAN NOT NULL DEFAULT FALSE,
     due_date date NOT NULL DEFAULT NOW(),
@@ -33,23 +47,10 @@ CREATE TRIGGER trig_todo_update_time BEFORE UPDATE ON todo
 CREATE TRIGGER trig_todo_item_update_time BEFORE UPDATE ON todo_item
     FOR EACH ROW EXECUTE PROCEDURE update_time_trigger();
 
--- Add recurring template table for storing recurrence rules
-CREATE TABLE recurring_template (
-    template_id uuid PRIMARY KEY,
-    todo_id uuid NOT NULL REFERENCES todo (todo_id) ON DELETE CASCADE,
-    title TEXT NOT NULL,
-    recurrence_period INTERVAL NOT NULL,
-    start_date DATE NOT NULL,
-    end_date DATE NULL,
-    last_generated_date DATE NULL,
-    is_active BOOLEAN NOT NULL DEFAULT TRUE,
-    create_time timestamptz NOT NULL DEFAULT NOW(),
-    update_time timestamptz NOT NULL DEFAULT NOW()
-);
-
 -- Add update trigger for recurring_template
 CREATE TRIGGER trig_recurring_template_update_time BEFORE UPDATE ON recurring_template
     FOR EACH ROW EXECUTE PROCEDURE update_time_trigger();
 
 -- Add index for efficient queries on active templates
 CREATE INDEX idx_recurring_template_active ON recurring_template (is_active, last_generated_date) WHERE is_active = TRUE;
+CREATE INDEX idx_todo_item_recurring_template_id ON todo_item (recurring_template_id) WHERE recurring_template_id IS NOT NULL;

--- a/backend/src/configuration.rs
+++ b/backend/src/configuration.rs
@@ -9,6 +9,7 @@ const CONFIGURATION_FILE: &str = "base.yaml";
 pub struct Settings {
     pub application: ApplicationSettings,
     pub database: DatabaseSettings,
+    pub recurring: RecurringSettings,
 }
 
 pub enum Environment {
@@ -44,6 +45,13 @@ pub struct ApplicationSettings {
     pub host: String,
     pub port: u16,
     pub validate_db_on_startup: Option<bool>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct RecurringSettings {
+    /// Duration in advance to create recurring todo items
+    #[serde(with = "humantime_serde")]
+    pub advance_days: Duration,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]

--- a/backend/src/domain/todo_item.rs
+++ b/backend/src/domain/todo_item.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 pub struct NewTodoItemRequest {
     pub title: String,
     pub due_date: Date,
+    pub recurring_template_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone)]

--- a/backend/src/extractors.rs
+++ b/backend/src/extractors.rs
@@ -1,31 +1,38 @@
-use axum::{
-    extract::{FromRef, FromRequestParts},
-    http::request::Parts,
-};
+use axum::{extract::FromRequestParts, http::request::Parts};
 use eyre::WrapErr;
-use sqlx::PgPool;
 
-use crate::error::InternalError;
+use crate::{configuration::RecurringSettings, error::InternalError, AppState};
 
 // we can also write a custom extractor that grabs a connection from the pool
 // which setup is appropriate depends on your application
 pub struct DatabaseConnection(pub sqlx::pool::PoolConnection<sqlx::Postgres>);
 
-impl<S> FromRequestParts<S> for DatabaseConnection
-where
-    PgPool: FromRef<S>,
-    S: Send + Sync,
-{
+impl FromRequestParts<AppState> for DatabaseConnection {
     type Rejection = InternalError;
 
-    async fn from_request_parts(_parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let pool = PgPool::from_ref(state);
-
-        let conn = pool
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let conn = state
+            .pool
             .acquire()
             .await
             .context("acquiring database connection from pool")?;
 
         Ok(Self(conn))
+    }
+}
+
+pub struct AppRecurringSettings(pub RecurringSettings);
+
+impl FromRequestParts<AppState> for AppRecurringSettings {
+    type Rejection = InternalError;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(Self(state.recurring_settings.clone()))
     }
 }

--- a/backend/src/repos/recurring_template.rs
+++ b/backend/src/repos/recurring_template.rs
@@ -1,5 +1,6 @@
 use eyre::eyre;
 use sqlx::{postgres::types::PgInterval, PgTransaction};
+use std::time::Duration;
 use time::Date;
 use uuid::Uuid;
 
@@ -263,7 +264,13 @@ pub async fn delete_recurring_template(
 pub async fn get_templates_due_for_generation(
     transaction: &mut PgTransaction<'_>,
     current_date: Date,
+    advance_duration: Duration,
 ) -> Result<ListRecurringTemplate, APIError> {
+    // Convert Duration to PgInterval
+    let advance_interval =
+        PgInterval::try_from(std::time::Duration::from_secs(advance_duration.as_secs()))
+            .map_err(|e| APIError::Internal(eyre!(e).into()))?;
+
     match sqlx::query_as!(
         GetTemplateQuery,
         r#"SELECT r.template_id, t.name as todo_name, r.title, r.recurrence_period, r.start_date, r.end_date, r.last_generated_date,
@@ -271,15 +278,37 @@ pub async fn get_templates_due_for_generation(
            FROM recurring_template as r
            INNER JOIN todo as t ON t.todo_id = r.todo_id
            WHERE r.is_active = TRUE
-             AND (r.end_date IS NULL OR r.end_date >= $1)
-             AND (r.last_generated_date IS NULL OR $1::date >= (r.last_generated_date + r.recurrence_period)::date)
-             AND $1::date >= r.start_date"#,
+             AND (r.end_date IS NULL OR r.end_date >= ($1::date + $2::interval)::date)
+             AND (r.last_generated_date IS NULL OR $1::date >= (r.last_generated_date + r.recurrence_period - $2::interval)::date)
+             AND $1::date >= (r.start_date - $2::interval)::date"#,
         current_date,
+        advance_interval,
     )
     .fetch_all(&mut **transaction)
     .await
     {
         Ok(result) => Ok(result.try_into()?),
+        Err(err) => Err(APIError::Internal(err.into())),
+    }
+}
+
+#[tracing::instrument(name = "Check if active todo exists for template", skip(transaction))]
+pub async fn check_active_todo_exists_for_template(
+    transaction: &mut PgTransaction<'_>,
+    template_id: &Uuid,
+) -> Result<bool, APIError> {
+    match sqlx::query!(
+        r#"SELECT EXISTS(
+            SELECT 1 FROM todo_item ti
+            WHERE ti.recurring_template_id = $1
+            AND ti.is_complete = FALSE
+        ) as exists"#,
+        template_id,
+    )
+    .fetch_one(&mut **transaction)
+    .await
+    {
+        Ok(result) => Ok(result.exists.unwrap_or(false)),
         Err(err) => Err(APIError::Internal(err.into())),
     }
 }

--- a/backend/src/repos/todo_item.rs
+++ b/backend/src/repos/todo_item.rs
@@ -24,13 +24,14 @@ pub async fn create_todo_item(
     let todo = get_todo_by_name(transaction, todo_name).await?;
     let result = sqlx::query_as!(
         TodoItem,
-        r#"INSERT INTO todo_item (todo_item_id, todo_id, title, due_date) VALUES ($1, $2, $3, $4)
+        r#"INSERT INTO todo_item (todo_item_id, todo_id, title, due_date, recurring_template_id) VALUES ($1, $2, $3, $4, $5)
            RETURNING todo_item_id, title, due_date, is_complete, complete_time, create_time, update_time
            ;"#,
         Uuid::new_v4(),
         todo.todo_id,
         req.title,
         req.due_date,
+        req.recurring_template_id,
     )
     .fetch_one(&mut **transaction)
     .await?;

--- a/backend/src/routes/todo_item.rs
+++ b/backend/src/routes/todo_item.rs
@@ -71,6 +71,7 @@ impl TryFrom<CreateTodoItemRequest> for NewTodoItemRequest {
         Ok(Self {
             title: value.title,
             due_date,
+            recurring_template_id: None, // Regular todo items are not linked to templates
         })
     }
 }

--- a/backend/src/services/recurring.rs
+++ b/backend/src/services/recurring.rs
@@ -1,20 +1,25 @@
 use eyre::{Context, Result};
 use sqlx::PgPool;
+use std::time::Duration;
 use time::OffsetDateTime;
 use tracing::{error, info, warn};
 
 use crate::{
     domain::{ListRecurringTemplateSingle, NewTodoItemRequest},
-    repos::{create_todo_item, get_templates_due_for_generation, update_last_generated_date},
+    repos::{
+        check_active_todo_exists_for_template, create_todo_item, get_templates_due_for_generation,
+        update_last_generated_date,
+    },
 };
 
 #[tracing::instrument(name = "Process recurring templates", skip(pool))]
-pub async fn process_recurring_templates(pool: &PgPool) -> Result<()> {
+pub async fn process_recurring_templates(pool: &PgPool, advance_duration: Duration) -> Result<()> {
     let current_date = OffsetDateTime::now_utc().date();
 
+    let advance_days = advance_duration.as_secs() / (24 * 60 * 60);
     info!(
-        "Starting recurring template processing for date: {}",
-        current_date
+        "Starting recurring template processing for date: {} (advance_days: {})",
+        current_date, advance_days
     );
 
     let mut transaction = pool
@@ -22,9 +27,10 @@ pub async fn process_recurring_templates(pool: &PgPool) -> Result<()> {
         .await
         .context("Failed to acquire database transaction")?;
 
-    let templates = get_templates_due_for_generation(&mut transaction, current_date)
-        .await
-        .context("Failed to get templates due for generation")?;
+    let templates =
+        get_templates_due_for_generation(&mut transaction, current_date, advance_duration)
+            .await
+            .context("Failed to get templates due for generation")?;
 
     if templates.items.is_empty() {
         info!("No recurring templates due for generation");
@@ -41,7 +47,7 @@ pub async fn process_recurring_templates(pool: &PgPool) -> Result<()> {
     let mut error_count = 0;
 
     for template in templates.items {
-        match process_single_template(&mut transaction, &template).await {
+        match process_single_template(&mut transaction, &template, advance_duration).await {
             Ok(_) => {
                 generated_count += 1;
                 info!(
@@ -84,6 +90,7 @@ pub async fn process_recurring_templates(pool: &PgPool) -> Result<()> {
 pub async fn process_single_template(
     transaction: &mut sqlx::PgTransaction<'_>,
     template: &ListRecurringTemplateSingle,
+    advance_duration: Duration,
 ) -> Result<()> {
     let current_date = OffsetDateTime::now_utc().date();
 
@@ -105,9 +112,28 @@ pub async fn process_single_template(
         }
     }
 
+    // Check if an active todo item already exists for this template
+    let active_todo_exists =
+        check_active_todo_exists_for_template(transaction, &template.template_id)
+            .await
+            .context("Failed to check for existing active todo")?;
+
+    if active_todo_exists {
+        info!(
+            "Active todo already exists for template {} ({}), skipping generation",
+            template.title, template.template_id
+        );
+        return Ok(());
+    }
+
+    // Set due date based on configured advance duration
+    let advance_days = advance_duration.as_secs() / (24 * 60 * 60);
+    let due_date = current_date + time::Duration::days(advance_days as i64);
+
     let new_item_request = NewTodoItemRequest {
         title: template.title.clone(),
-        due_date: current_date,
+        due_date,
+        recurring_template_id: Some(template.template_id),
     };
 
     create_todo_item(transaction, &template.todo_name, &new_item_request)
@@ -119,4 +145,72 @@ pub async fn process_single_template(
         .context("Failed to update last generated date")?;
 
     Ok(())
+}
+
+#[tracing::instrument(
+    name = "Generate advance todos for new template",
+    skip(transaction),
+    fields(template_id = %template.template_id, title = %template.title)
+)]
+pub async fn generate_advance_todos_for_template(
+    transaction: &mut sqlx::PgTransaction<'_>,
+    template: &ListRecurringTemplateSingle,
+    advance_duration: Duration,
+) -> Result<usize> {
+    let current_date = OffsetDateTime::now_utc().date();
+    let advance_days = advance_duration.as_secs() / (24 * 60 * 60);
+    let advance_window_end = current_date + time::Duration::days(advance_days as i64);
+    let next_generation_date = template.start_date.max(current_date);
+    let due_date = next_generation_date + time::Duration::days(advance_days as i64);
+    if due_date > advance_window_end {
+        return Ok(0);
+    }
+    // Check if we've reached the end date
+    if let Some(end_date) = template.end_date {
+        if next_generation_date > end_date {
+            return Ok(0);
+        }
+    }
+
+    let active_todo_exists =
+        check_active_todo_exists_for_template(transaction, &template.template_id)
+            .await
+            .context("Failed to check for existing active todo")?;
+    if active_todo_exists {
+        return Ok(0);
+    }
+    let mut generated_count = 0;
+
+    info!(
+        "Generating advance todos for template {} from {} to {}",
+        template.template_id, next_generation_date, advance_window_end
+    );
+
+    let new_item_request = NewTodoItemRequest {
+        title: template.title.clone(),
+        due_date,
+        recurring_template_id: Some(template.template_id),
+    };
+
+    create_todo_item(transaction, &template.todo_name, &new_item_request)
+        .await
+        .context("Failed to create advance todo item from template")?;
+
+    generated_count += 1;
+
+    info!(
+        "Created advance todo for template {} with due date {}",
+        template.template_id, due_date
+    );
+
+    // Update last generated date to current date (not the due date)
+    update_last_generated_date(transaction, &template.template_id, current_date)
+        .await
+        .context("Failed to update last generated date")?;
+    info!(
+        "Generated {} advance todos for template {}",
+        generated_count, template.template_id
+    );
+
+    Ok(generated_count)
 }

--- a/backend/src/startup.rs
+++ b/backend/src/startup.rs
@@ -36,9 +36,10 @@ impl Application {
         }
 
         // Setup recurring templates scheduler
-        let scheduler = setup_recurring_scheduler(&pool).await?;
+        let scheduler =
+            setup_recurring_scheduler(&pool, configuration.recurring.advance_days).await?;
 
-        let server = run(listener, pool).await?;
+        let server = run(listener, pool, configuration.recurring).await?;
         Ok(Application {
             server,
             port,
@@ -65,7 +66,10 @@ pub fn get_connection_pool(configuration: &DatabaseSettings) -> PgPool {
         .connect_lazy_with(configuration.connection_options())
 }
 
-async fn setup_recurring_scheduler(pool: &PgPool) -> Result<JobScheduler> {
+async fn setup_recurring_scheduler(
+    pool: &PgPool,
+    advance_duration: std::time::Duration,
+) -> Result<JobScheduler> {
     let scheduler = JobScheduler::new()
         .await
         .context("Failed to create job scheduler")?;
@@ -75,7 +79,7 @@ async fn setup_recurring_scheduler(pool: &PgPool) -> Result<JobScheduler> {
         let pool = pool_clone.clone();
         Box::pin(async move {
             info!("Starting daily recurring templates job");
-            if let Err(e) = process_recurring_templates(&pool).await {
+            if let Err(e) = process_recurring_templates(&pool, advance_duration).await {
                 error!("Recurring templates processing failed: {}", e);
             } else {
                 info!("Daily recurring templates job completed successfully");

--- a/backend/tests/api/helpers.rs
+++ b/backend/tests/api/helpers.rs
@@ -227,6 +227,13 @@ impl TestApp {
             .expect("Failed to execute request")
     }
 
+    pub async fn process_recurring_templates(
+        &self,
+        advance_duration: std::time::Duration,
+    ) -> eyre::Result<()> {
+        checklist::services::process_recurring_templates(&self.db_pool, advance_duration).await
+    }
+
     pub async fn list_recurring_templates(&self, todo_name: &str) -> reqwest::Response {
         self.client
             .get(format!("{}/todo/{}/recurring", self.address, todo_name))

--- a/backend/tests/api/recurring_template.rs
+++ b/backend/tests/api/recurring_template.rs
@@ -31,13 +31,300 @@ async fn create_recurring_template_works() {
     let expected: serde_json::Value = response.json().await.unwrap();
     app.golden.check_diff_json("create_template", &expected);
 
-    // Verify a todo item was created (should happen automatically now)
+    // Verify a todo item was created immediately (advance generation)
     let items_after = app.list_todo_items(todo_name).await;
     assert_response(&items_after, StatusCode::OK);
     let items_after_json: serde_json::Value = items_after.json().await.unwrap();
     let todo_items = items_after_json["items"].as_array().unwrap();
     assert_eq!(todo_items.len(), 1);
     assert_eq!(todo_items[0]["title"].as_str().unwrap(), "Daily task");
+
+    // Verify the due date is 7 days from now
+    let due_date_str = todo_items[0]["due_date"].as_str().unwrap();
+    let due_date = time::Date::parse(
+        due_date_str,
+        &time::format_description::well_known::Iso8601::DATE,
+    )
+    .unwrap();
+    let expected_due_date = time::OffsetDateTime::now_utc().date() + time::Duration::days(7);
+    assert_eq!(due_date, expected_due_date);
+}
+
+#[tokio::test]
+async fn recurring_template_creates_todo_one_week_in_advance() {
+    let app = spawn_app().await;
+    let todo_name = "recurring_advance";
+
+    create_todo(&app, todo_name).await;
+
+    // Create a template with start date far in the future (beyond 7-day window)
+    // so no immediate todo creation happens
+    let far_future_start = time::OffsetDateTime::now_utc().date() + time::Duration::days(20);
+    let payload = json!({
+        "title": "Weekly advance task",
+        "recurrence_interval": {
+            "days": 1
+        },
+        "start_date": far_future_start.to_string(),
+        "end_date": null
+    });
+    let response = app.post_recurring_template(todo_name, &payload).await;
+    assert_response(&response, StatusCode::OK);
+
+    // Verify no todo items exist initially (start date is too far in future)
+    let initial_items = app.list_todo_items(todo_name).await;
+    assert_response(&initial_items, StatusCode::OK);
+    let initial_items_json: serde_json::Value = initial_items.json().await.unwrap();
+    let initial_todo_items = initial_items_json["items"].as_array().unwrap();
+    assert_eq!(initial_todo_items.len(), 0);
+
+    // Simulate time passing: update the template to have start_date = today
+    // This makes the template eligible for the scheduler's 7-day advance processing
+    let template_response: serde_json::Value = response.json().await.unwrap();
+    let template_id_str = template_response["template_id"].as_str().unwrap();
+    let template_id = uuid::Uuid::parse_str(template_id_str).unwrap();
+
+    let current_date = time::OffsetDateTime::now_utc().date();
+
+    // Update the database to simulate the template becoming active today
+    sqlx::query!(
+        "UPDATE recurring_template SET start_date = $1 WHERE template_id = $2",
+        current_date,
+        template_id
+    )
+    .execute(&app.db_pool)
+    .await
+    .unwrap();
+
+    // Process recurring templates - this tests the scheduler's 7-day advance logic
+    app.process_recurring_templates(std::time::Duration::from_secs(7 * 24 * 60 * 60))
+        .await
+        .unwrap();
+
+    // Verify a todo item was created
+    let items_after = app.list_todo_items(todo_name).await;
+    assert_response(&items_after, StatusCode::OK);
+    let items_after_json: serde_json::Value = items_after.json().await.unwrap();
+    let todo_items = items_after_json["items"].as_array().unwrap();
+    assert_eq!(todo_items.len(), 1);
+    assert_eq!(
+        todo_items[0]["title"].as_str().unwrap(),
+        "Weekly advance task"
+    );
+
+    // Parse the due date and verify it's 7 days from now
+    let due_date_str = todo_items[0]["due_date"].as_str().unwrap();
+    let due_date = time::Date::parse(
+        due_date_str,
+        &time::format_description::well_known::Iso8601::DATE,
+    )
+    .unwrap();
+    let current_date = time::OffsetDateTime::now_utc().date();
+    let expected_due_date = current_date + time::Duration::days(7);
+    assert_eq!(due_date, expected_due_date);
+
+    // Process again - should not create another todo item because one already exists
+    app.process_recurring_templates(std::time::Duration::from_secs(7 * 24 * 60 * 60))
+        .await
+        .unwrap();
+
+    let items_after_second = app.list_todo_items(todo_name).await;
+    assert_response(&items_after_second, StatusCode::OK);
+    let items_after_second_json: serde_json::Value = items_after_second.json().await.unwrap();
+    let todo_items_second = items_after_second_json["items"].as_array().unwrap();
+    assert_eq!(todo_items_second.len(), 1); // Still only one item
+}
+
+#[tokio::test]
+async fn recurring_template_creates_todo_with_proper_relationship() {
+    let app = spawn_app().await;
+    let todo_name = "recurr_rel";
+
+    create_todo(&app, todo_name).await;
+
+    // Create a daily recurring template
+    let payload = json!({
+        "title": "Relationship test task",
+        "recurrence_interval": {
+            "days": 1
+        },
+        "start_date": "2020-01-01",
+        "end_date": null
+    });
+    let response = app.post_recurring_template(todo_name, &payload).await;
+    assert_response(&response, StatusCode::OK);
+    let template_response: serde_json::Value = response.json().await.unwrap();
+    let template_id = template_response["template_id"].as_str().unwrap();
+
+    // Process recurring templates - this should create a todo item linked to the template
+    app.process_recurring_templates(std::time::Duration::from_secs(7 * 24 * 60 * 60))
+        .await
+        .unwrap();
+
+    // Verify a todo item was created
+    let items_after = app.list_todo_items(todo_name).await;
+    assert_response(&items_after, StatusCode::OK);
+    let items_after_json: serde_json::Value = items_after.json().await.unwrap();
+    let todo_items = items_after_json["items"].as_array().unwrap();
+    assert_eq!(todo_items.len(), 1);
+    assert_eq!(
+        todo_items[0]["title"].as_str().unwrap(),
+        "Relationship test task"
+    );
+
+    // Verify the foreign key relationship by checking the database directly
+    let todo_item_id = todo_items[0]["todo_item_id"].as_str().unwrap();
+    let todo_item_uuid = uuid::Uuid::parse_str(todo_item_id).unwrap();
+
+    // Check that the todo item has the correct recurring_template_id
+    let query_result = sqlx::query!(
+        "SELECT recurring_template_id FROM todo_item WHERE todo_item_id = $1",
+        todo_item_uuid
+    )
+    .fetch_one(&app.db_pool)
+    .await
+    .unwrap();
+
+    assert!(query_result.recurring_template_id.is_some());
+    assert_eq!(
+        query_result.recurring_template_id.unwrap().to_string(),
+        template_id
+    );
+
+    // Create a second regular todo item (not from template) in the same todo
+    let regular_payload = json!({
+        "title": "Regular task"
+    });
+    let regular_response = app.post_todo_item(todo_name, &regular_payload).await;
+    assert_response(&regular_response, StatusCode::OK);
+
+    // Verify regular todo item doesn't have a recurring_template_id
+    let regular_response_json: serde_json::Value = regular_response.json().await.unwrap();
+    let regular_todo_item_id = regular_response_json["todo_item_id"].as_str().unwrap();
+    let regular_todo_item_uuid = uuid::Uuid::parse_str(regular_todo_item_id).unwrap();
+
+    let regular_query_result = sqlx::query!(
+        "SELECT recurring_template_id FROM todo_item WHERE todo_item_id = $1",
+        regular_todo_item_uuid
+    )
+    .fetch_one(&app.db_pool)
+    .await
+    .unwrap();
+
+    assert!(regular_query_result.recurring_template_id.is_none());
+}
+
+#[tokio::test]
+async fn recurring_template_with_future_start_date_creates_no_todos() {
+    let app = spawn_app().await;
+    let todo_name = "future_start";
+
+    create_todo(&app, todo_name).await;
+
+    // Create a template with start date far in the future
+    let future_date = time::OffsetDateTime::now_utc().date() + time::Duration::days(30);
+    let payload = json!({
+        "title": "Future task",
+        "recurrence_interval": {
+            "days": 1
+        },
+        "start_date": future_date.to_string(),
+        "end_date": null
+    });
+    let response = app.post_recurring_template(todo_name, &payload).await;
+    assert_response(&response, StatusCode::OK);
+
+    // Verify no todo items were created (start date is too far in future)
+    let items_after = app.list_todo_items(todo_name).await;
+    assert_response(&items_after, StatusCode::OK);
+    let items_after_json: serde_json::Value = items_after.json().await.unwrap();
+    let todo_items = items_after_json["items"].as_array().unwrap();
+    assert_eq!(todo_items.len(), 0);
+}
+
+#[tokio::test]
+async fn updating_recurring_template_creates_todo_when_necessary() {
+    let app = spawn_app().await;
+    let todo_name = "update_test";
+
+    create_todo(&app, todo_name).await;
+
+    // Create a template with start date far in the future (no immediate todo creation)
+    let far_future_start = time::OffsetDateTime::now_utc().date() + time::Duration::days(20);
+    let payload = json!({
+        "title": "Update test task",
+        "recurrence_interval": {
+            "days": 1
+        },
+        "start_date": far_future_start.to_string(),
+        "end_date": null
+    });
+    let response = app.post_recurring_template(todo_name, &payload).await;
+    assert_response(&response, StatusCode::OK);
+    let template_response: serde_json::Value = response.json().await.unwrap();
+    let template_id = template_response["template_id"].as_str().unwrap();
+
+    // Verify no todo items exist initially
+    let initial_items = app.list_todo_items(todo_name).await;
+    assert_response(&initial_items, StatusCode::OK);
+    let initial_items_json: serde_json::Value = initial_items.json().await.unwrap();
+    let initial_todo_items = initial_items_json["items"].as_array().unwrap();
+    assert_eq!(initial_todo_items.len(), 0);
+
+    // Update the template to have start_date = today (this should trigger todo creation)
+    let current_date = time::OffsetDateTime::now_utc().date();
+    let update_payload = json!({
+        "title": "Updated task title",
+        "recurrence_interval": {
+            "days": 1
+        },
+        "start_date": current_date.to_string(),
+        "end_date": null,
+        "is_active": true
+    });
+    let update_response = app
+        .update_recurring_template(todo_name, template_id, &update_payload)
+        .await;
+    assert_response(&update_response, StatusCode::OK);
+
+    // Verify a todo item was created during the update
+    let items_after_update = app.list_todo_items(todo_name).await;
+    assert_response(&items_after_update, StatusCode::OK);
+    let items_after_update_json: serde_json::Value = items_after_update.json().await.unwrap();
+    let todo_items_after_update = items_after_update_json["items"].as_array().unwrap();
+    assert_eq!(todo_items_after_update.len(), 1);
+    assert_eq!(
+        todo_items_after_update[0]["title"].as_str().unwrap(),
+        "Updated task title"
+    );
+
+    // Verify the due date is 7 days from now
+    let due_date_str = todo_items_after_update[0]["due_date"].as_str().unwrap();
+    let due_date = time::Date::parse(
+        due_date_str,
+        &time::format_description::well_known::Iso8601::DATE,
+    )
+    .unwrap();
+    let expected_due_date = current_date + time::Duration::days(7);
+    assert_eq!(due_date, expected_due_date);
+
+    // Verify the todo item is properly linked to the template
+    let todo_item_id = todo_items_after_update[0]["todo_item_id"].as_str().unwrap();
+    let todo_item_uuid = uuid::Uuid::parse_str(todo_item_id).unwrap();
+
+    let query_result = sqlx::query!(
+        "SELECT recurring_template_id FROM todo_item WHERE todo_item_id = $1",
+        todo_item_uuid
+    )
+    .fetch_one(&app.db_pool)
+    .await
+    .unwrap();
+
+    assert!(query_result.recurring_template_id.is_some());
+    assert_eq!(
+        query_result.recurring_template_id.unwrap().to_string(),
+        template_id
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
- Add configurable advance_days setting (default: 7 days) in configuration
- Enhance recurring template generation to create todos 7 days in advance
- Add recurring_template_id foreign key to todo_item for better relationships
- Implement logic to prevent duplicate active todos for same template
- Add comprehensive test coverage for advance generation scenarios
- Update database schema to support template-todo item relationships
- Refactor recurring service to support configurable advance windows

🤖 Generated with [Claude Code](https://claude.ai/code)